### PR TITLE
More continuous sending of sensations

### DIFF
--- a/owo_suit.py
+++ b/owo_suit.py
@@ -70,7 +70,7 @@ class OWOSuit:
                         self.gui.handle_active_muscle_reset()
             except RuntimeError:  # race condition for set changing during iteration
                 pass
-            time.sleep(.3)
+            time.sleep(.2)
 
     def on_collission_enter(self, address: str, *args) -> None:
         if address not in self.osc_parameters:


### PR DESCRIPTION
I reduced the timing between sending of sensations so it has less downtime between the sensations and changed the send sensations so it activates all zones at once, instead of trying to activate them after each other, causing it to override the existing zone